### PR TITLE
db/projects: move glibc to ghe operating-systems tag

### DIFF
--- a/db/projects.ts
+++ b/db/projects.ts
@@ -660,7 +660,7 @@ export const PROJECTS = [
   },
   {
     isEnable: true,
-    tag: 'operating-system',
+    tag: 'operating-systems',
     name: 'The GNU C Library (glibc)',
     description: 'The core system library of (not just) Linux systems',
     repositoryURL: 'https://sourceware.org/git/?p=glibc.git',


### PR DESCRIPTION
The glibc is the only open-source project tagged as 'operating-system'
instead of 'operating-systems'. Fix this as it seems a typo.