### PR TITLE
fix broken formatting for recommended licenses

### DIFF
--- a/pages/legal/policy.tsx
+++ b/pages/legal/policy.tsx
@@ -186,12 +186,16 @@ export default function Policy() {
 
 <h4 className="font-medium" id="new-projects-licensing-recommendation">New Projects licensing recommendation</h4>
 
-<p>The following are SUSE’s preferred licenses for new contributions:
-* Apache 2.0 (code)
-* CC BY-SA 4.0 (documentation and artwork)</p>
+<p className="font-light" >The following are SUSE’s preferred licenses for new contributions:</p>
+<ul>
+<li>Apache 2.0 (code)</li>
+<li>CC BY-SA 4.0 (documentation and artwork)</li>
+</ul>
 
-<p>For projects with a copyleft context:
-* GPL-2.0-or-later</p>
+<p className="font-light">For projects with a copyleft context:</p>
+<ul>
+<li>GPL-2.0-or-later</li>
+</ul>
 
 <p>If not following recommended license category choices a reasonable explanation for the non-standard license selection must be provided to legal@suse.de.</p>
 


### PR DESCRIPTION
The list of recommended licenses has currently broken formatting.

I'm not 100% sure if the light text is a good choice here as we don't use it anywhere else,  using simply bold resulted in text comparable with h2 which would be an overkill.


Before
![Screenshot from 2023-02-28 09-25-08](https://user-images.githubusercontent.com/510119/221795923-1fc3205d-369d-4e20-bd6f-8c7330273081.png)

After
![Screenshot from 2023-02-28 09-24-36](https://user-images.githubusercontent.com/510119/221795983-8b94205f-7bf5-475d-a261-40b5fe39a1b6.png)


