### PR TITLE
Set trento repo URL to main project page

### DIFF
--- a/db/featured.ts
+++ b/db/featured.ts
@@ -98,7 +98,7 @@ export const FEATURED_PROJECTS = [
     name: 'Trento',
     description: 'An open cloud-native web console to manage OS-related tasks for SAP applications.',
     href: 'https://www.trento-project.io/',
-    repositoryURL: 'https://github.com/trento-project/trento',
+    repositoryURL: 'https://github.com/trento-project',
     twitterURL: '',
     documentationURL: '',
   },


### PR DESCRIPTION
Change Trento's repo URL to main project page at https://github.com/trento-project.