### PR TITLE
fix: update Kubewarden card

### DIFF
--- a/db/featured.ts
+++ b/db/featured.ts
@@ -66,8 +66,8 @@ export const FEATURED_PROJECTS = [
     description: 'Kubernetes admission control using WebAssembly (WASM).',
     href: 'https://kubewarden.io/',
     repositoryURL: 'https://github.com/kubewarden',
-    twitterURL: 'https://twitter.com/kubewarden',
-    documentationURL: '',
+    twitterURL: '',
+    documentationURL: 'https://docs.kubewarden.io/',
   },
   {
     color: '#045209',


### PR DESCRIPTION
- Remove link to Twitter, the project moved to mastodon and bluesky. We can add links once we have icons for them
- Add link to documentation
